### PR TITLE
Enable Github actions to build and release AMD64 and ARM64 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - local_test
+      - Local_test
     tags:
       - v*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - local_test
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF##*/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u odidev -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            odidev/teams-notification-resource:${{ steps.prepare.outputs.tag_name }}
+            odidev/teams-notification-resource:latest


### PR DESCRIPTION
Hi

Package Owner: Abhishek Nishant

PR change Details:

Patch Details: Following file has been created :

Added .github/workflows/ci.yml file to build and push the image for both amd64 and arm64 platforms.

PR Description: Here is my commit message :
Release docker image for arm64.

PR Description:

The following file has been created :
Added github/workflows/ci.yml file to build and push the image for both amd64 and arm64 platforms.

Signed-off-by: odidev odidev@puresoftware.com
Reviewer: Pruthvi Teja Reddy
Thanks
Abhishek Nishant